### PR TITLE
게시글 컨트롤러의 해시태그 기능 변경점 반영

### DIFF
--- a/src/main/java/com/example/board/controller/ArticleController.java
+++ b/src/main/java/com/example/board/controller/ArticleController.java
@@ -41,6 +41,8 @@ public class ArticleController {
         map.addAttribute("articles", articles);
         map.addAttribute("paginationBarNumbers", barNumbers);
         map.addAttribute("searchTypes", SearchType.values());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
+
 
         return "articles/index";
     }
@@ -52,6 +54,7 @@ public class ArticleController {
         map.addAttribute("article", article);
         map.addAttribute("articleComments", article.articleCommentsResponse());
         map.addAttribute("totalCount", articleService.getArticleCount());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/detail";
     }


### PR DESCRIPTION
이 정보는 뷰에서 해시태그에 링크를 달 때
게시글의 검색 필터 정보로 쓰기 위해 필요하다.

* TODO: `searchTypes`에서 재활용할 수 있는 데이터이므로 더 나은 방법이 있을지 고민해보자.

테스트의 변화는 #38 의 fe96bfe 에서 도메인 변경을 하면서 이미 구상하여 작업하였음.

closes #38 