### PR TITLE
Swagger UI 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ repositories {
 
 dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.12'
+    implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.12'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -37,6 +40,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    annotationProcessor 'com.github.therapi:therapi-runtime-javadoc-scribe:0.15.0'
 
     // queryDSL 설정
     implementation "com.querydsl:querydsl-jpa"


### PR DESCRIPTION
* 간단한 의존성 추가만으로 즉시 스웨거 문서화가 진행됨.
* 이때, Spring Data Rest가 자동으로 만들어 준 api를 스웨거에 노출시키기 위해 추가 의존성을 사용함.

closes #64 